### PR TITLE
feat(phase4): add medium-level execution staging

### DIFF
--- a/phases/phase1_ingestion.py
+++ b/phases/phase1_ingestion.py
@@ -4,8 +4,448 @@ Owner: Aadyaa
 Purpose:
 - Load raw data and perform deterministic validation.
 Responsibilities:
-- Read files from data/raw.
-- Perform rule-based validation.
-- Split dataset into clean and anomaly datasets.
-- Save results to data/clean and data/anomalies.
+- Read local CSV/JSON input from context.
+- Split rows into clean rows and anomaly rows.
+- Preserve a downstream-safe context contract for Phase 2.
 """
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import os
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+logger = logging.getLogger(__name__)
+
+NULL_LIKE_VALUES = {"", "null", "none", "na", "n/a", "nan", "missing", "unknown"}
+DATE_COLUMN_HINTS = ("date", "time", "timestamp", "dob")
+EMAIL_COLUMN_HINTS = ("email", "mail")
+NUMERIC_COLUMN_HINTS = (
+    "amount",
+    "price",
+    "cost",
+    "total",
+    "count",
+    "qty",
+    "quantity",
+    "number",
+    "score",
+    "value",
+    "rate",
+    "percent",
+    "balance",
+)
+DATE_FORMATS = (
+    "%Y-%m-%d",
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d %H:%M:%S",
+)
+EMAIL_PATTERN = re.compile(r"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$")
+
+
+def _ensure_dir(path: str) -> None:
+    if path:
+        os.makedirs(path, exist_ok=True)
+
+
+def _normalize_source_name(source_name: str, input_path: str, raw_dir: str) -> str:
+    if source_name:
+        return source_name
+    if input_path:
+        return Path(input_path).stem
+    if raw_dir:
+        return Path(raw_dir).name or "phase1_input"
+    return "phase1_input"
+
+
+def _resolve_input_path(context: dict[str, Any]) -> str:
+    candidate_keys = ("input_path", "source_file", "dataset_path", "file_path")
+    for key in candidate_keys:
+        value = context.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    raw_dir = context.get("raw_dir")
+    if not isinstance(raw_dir, str) or not raw_dir.strip():
+        return ""
+
+    raw_path = Path(raw_dir)
+    if not raw_path.exists() or not raw_path.is_dir():
+        return ""
+
+    supported_files = sorted(
+        path for path in raw_path.iterdir() if path.is_file() and path.suffix.lower() in {".csv", ".json", ".jsonl"}
+    )
+    if not supported_files:
+        return ""
+    return str(supported_files[0])
+
+
+def _coerce_scalar(value: Any) -> Any:
+    return value
+
+
+def _load_csv_rows(path: Path) -> list[dict[str, Any]]:
+    with path.open("r", encoding="utf-8", newline="") as file:
+        reader = csv.DictReader(file)
+        return [{key: _coerce_scalar(value) for key, value in row.items()} for row in reader]
+
+
+def _load_json_rows(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if isinstance(payload, list):
+        return [{str(k): _coerce_scalar(v) for k, v in row.items()} for row in payload if isinstance(row, dict)]
+    if isinstance(payload, dict):
+        records = payload.get("records")
+        if isinstance(records, list):
+            return [{str(k): _coerce_scalar(v) for k, v in row.items()} for row in records if isinstance(row, dict)]
+        return [{str(k): _coerce_scalar(v) for k, v in payload.items()}]
+    raise ValueError(f"Unsupported JSON payload in {path}")
+
+
+def _load_jsonl_rows(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        obj = json.loads(line)
+        if isinstance(obj, dict):
+            rows.append({str(k): _coerce_scalar(v) for k, v in obj.items()})
+    return rows
+
+
+def _load_rows(input_path: str) -> list[dict[str, Any]]:
+    path = Path(input_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Input dataset not found: {input_path}")
+
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        return _load_csv_rows(path)
+    if suffix == ".json":
+        return _load_json_rows(path)
+    if suffix == ".jsonl":
+        return _load_jsonl_rows(path)
+    raise ValueError(f"Unsupported input format: {path.suffix}")
+
+
+def _is_null_like(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str):
+        return value.strip().lower() in NULL_LIKE_VALUES
+    return False
+
+
+def _looks_like_date_column(column_name: str) -> bool:
+    normalized = column_name.lower()
+    return any(token in normalized for token in DATE_COLUMN_HINTS)
+
+
+def _looks_like_email_column(column_name: str) -> bool:
+    normalized = column_name.lower()
+    return any(token in normalized for token in EMAIL_COLUMN_HINTS)
+
+
+def _looks_like_numeric_column(column_name: str) -> bool:
+    normalized = column_name.lower()
+    return any(token in normalized for token in NUMERIC_COLUMN_HINTS)
+
+
+def _is_valid_date(value: Any) -> bool:
+    if isinstance(value, datetime):
+        return True
+    if not isinstance(value, str):
+        return False
+    candidate = value.strip()
+    for date_format in DATE_FORMATS:
+        try:
+            datetime.strptime(candidate, date_format)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _is_valid_email(value: Any) -> bool:
+    if not isinstance(value, str):
+        return False
+    candidate = value.strip()
+    if candidate != value:
+        return False
+    if ".." in candidate:
+        return False
+    if candidate.startswith(".") or candidate.endswith("."):
+        return False
+    return bool(EMAIL_PATTERN.match(candidate))
+
+
+def _is_valid_numeric(value: Any) -> bool:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return True
+    if not isinstance(value, str):
+        return False
+    candidate = value.strip()
+    if not candidate or candidate != value:
+        return False
+    try:
+        float(candidate)
+        return True
+    except ValueError:
+        return False
+
+
+def _make_anomaly(
+    row: dict[str, Any],
+    row_index: int,
+    column_name: str,
+    value: Any,
+    error_type: str,
+    anomaly_hint: str,
+) -> dict[str, Any]:
+    anomaly_id = row.get("id", row_index)
+    return {
+        "id": anomaly_id,
+        "column_name": column_name,
+        "value": value,
+        "error_type": error_type,
+        "anomaly_hint": anomaly_hint,
+        "row_index": row_index,
+        "source_row": dict(row),
+    }
+
+
+def _validate_row(row: dict[str, Any], row_index: int) -> list[dict[str, Any]]:
+    anomalies: list[dict[str, Any]] = []
+
+    for column_name, value in row.items():
+        if _is_null_like(value):
+            anomalies.append(
+                _make_anomaly(
+                    row,
+                    row_index,
+                    column_name,
+                    value,
+                    "null_block_error",
+                    "value is missing or sentinel null",
+                )
+            )
+            continue
+
+        if _looks_like_date_column(column_name) and not _is_valid_date(value):
+            anomalies.append(
+                _make_anomaly(
+                    row,
+                    row_index,
+                    column_name,
+                    value,
+                    "date_format_error",
+                    "date token format mismatch",
+                )
+            )
+            continue
+
+        if _looks_like_email_column(column_name) and not _is_valid_email(value):
+            anomalies.append(
+                _make_anomaly(
+                    row,
+                    row_index,
+                    column_name,
+                    value,
+                    "email_format_error",
+                    "email token malformed address",
+                )
+            )
+            continue
+
+        if _looks_like_numeric_column(column_name) and not _is_valid_numeric(value):
+            anomalies.append(
+                _make_anomaly(
+                    row,
+                    row_index,
+                    column_name,
+                    value,
+                    "numeric_format_error",
+                    "amount contains numeric separator noise",
+                )
+            )
+
+    return anomalies
+
+
+def _write_clean_rows(path: str, rows: list[dict[str, Any]]) -> None:
+    output_path = Path(path)
+    _ensure_dir(str(output_path.parent))
+
+    if not rows:
+        output_path.write_text("", encoding="utf-8")
+        return
+
+    fieldnames: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        for key in row.keys():
+            if key not in seen:
+                seen.add(key)
+                fieldnames.append(key)
+
+    with output_path.open("w", encoding="utf-8", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _write_anomalies(path: str, anomalies: list[dict[str, Any]]) -> None:
+    output_path = Path(path)
+    _ensure_dir(str(output_path.parent))
+    output_path.write_text(
+        json.dumps(anomalies, ensure_ascii=True, indent=2, default=str),
+        encoding="utf-8",
+    )
+
+
+def save_pipeline_context(context: dict[str, Any], output_file: str | None = None) -> bool:
+    vault_dir = context.get("vault_dir", os.path.join("data", "vault"))
+    output_file = output_file or os.path.join(vault_dir, "phase1_context.json")
+    _ensure_dir(os.path.dirname(output_file))
+    with open(output_file, "w", encoding="utf-8") as handle:
+        json.dump(context, handle, default=str, indent=2)
+    return True
+
+
+def _build_failure_result(
+    context: dict[str, Any],
+    *,
+    phase1_status: str,
+    message: str,
+    validation_rules_applied: list[str],
+) -> dict[str, Any]:
+    updated_context = dict(context or {})
+    updated_context.update(
+        {
+            "phase1_status": phase1_status,
+            "phase1_summary": {
+                "input_rows": 0,
+                "clean_rows": 0,
+                "anomalies": 0,
+                "validation_rules_applied": validation_rules_applied,
+                "message": message,
+            },
+            "raw_rows": [],
+            "clean_rows": [],
+            "anomalies": [],
+            "phase1_clean_file": None,
+            "phase1_anomaly_file": None,
+        }
+    )
+    return updated_context
+
+
+def run(context: dict) -> dict:
+    """Run deterministic Phase 1 ingestion and return an updated context."""
+    updated_context = dict(context or {})
+    validation_rules_applied = [
+        "null_detection",
+        "date_format_detection",
+        "email_format_detection",
+        "numeric_format_detection",
+    ]
+
+    input_path = _resolve_input_path(updated_context)
+    raw_dir = str(updated_context.get("raw_dir", os.path.join("data", "raw")))
+    clean_dir = str(updated_context.get("clean_dir", os.path.join("data", "clean")))
+    anomalies_dir = str(updated_context.get("anomalies_dir", os.path.join("data", "anomalies")))
+    vault_dir = str(updated_context.get("vault_dir", os.path.join("data", "vault")))
+    source_name = _normalize_source_name(str(updated_context.get("source_name", "")), input_path, raw_dir)
+
+    if not input_path:
+        return _build_failure_result(
+            updated_context,
+            phase1_status="missing_input",
+            message="No local dataset path was provided.",
+            validation_rules_applied=validation_rules_applied,
+        )
+
+    try:
+        raw_rows = _load_rows(input_path)
+    except Exception as exc:
+        return _build_failure_result(
+            updated_context,
+            phase1_status="read_error",
+            message=str(exc),
+            validation_rules_applied=validation_rules_applied,
+        )
+
+    clean_rows: list[dict[str, Any]] = []
+    anomalies: list[dict[str, Any]] = []
+
+    for row_index, row in enumerate(raw_rows):
+        row_copy = dict(row)
+        row_copy.setdefault("row_index", row_index)
+        row_anomalies = _validate_row(row_copy, row_index)
+        if row_anomalies:
+            anomalies.extend(row_anomalies)
+        else:
+            clean_rows.append(row_copy)
+
+    _ensure_dir(clean_dir)
+    _ensure_dir(anomalies_dir)
+    _ensure_dir(vault_dir)
+
+    clean_file = os.path.join(clean_dir, f"{source_name}_clean_rows.csv")
+    anomaly_file = os.path.join(anomalies_dir, f"{source_name}_anomalies.json")
+    _write_clean_rows(clean_file, clean_rows)
+    _write_anomalies(anomaly_file, anomalies)
+
+    updated_context.update(
+        {
+            "input_path": input_path,
+            "source_name": source_name,
+            "vault_dir": vault_dir,
+            "raw_rows": raw_rows,
+            "clean_rows": clean_rows,
+            "anomalies": anomalies,
+            "phase1_status": "completed" if raw_rows else "no_rows",
+            "phase1_summary": {
+                "input_rows": len(raw_rows),
+                "clean_rows": len(clean_rows),
+                "anomalies": len(anomalies),
+                "validation_rules_applied": validation_rules_applied,
+            },
+            "phase1_clean_file": clean_file,
+            "phase1_anomaly_file": anomaly_file,
+        }
+    )
+
+    save_pipeline_context(updated_context)
+    return updated_context
+
+
+def ingest_and_validate(
+    raw_dir: str,
+    clean_dir: str,
+    anomalies_dir: str,
+    schema_path: str,
+    source_name: str = "source",
+    pk_columns: list[str] | None = None,
+    required_columns: list[str] | None = None,
+    vault_dir: str = os.path.join("data", "vault"),
+) -> dict[str, Any]:
+    context = {
+        "raw_dir": raw_dir,
+        "clean_dir": clean_dir,
+        "anomalies_dir": anomalies_dir,
+        "schema_path": schema_path,
+        "source_name": source_name,
+        "pk_columns": pk_columns or [],
+        "required_columns": required_columns or [],
+        "vault_dir": vault_dir,
+    }
+    return run(context)

--- a/phases/phase4_execution.py
+++ b/phases/phase4_execution.py
@@ -5,17 +5,24 @@ Purpose:
 - Validate and stage Phase 3 remediation outputs.
 Responsibilities:
 - Check remediation payload contract.
-- Prepare execution plan metadata for downstream guardrails.
-- Route invalid remediations to quarantine-style staging.
+- Safely apply remediation lambdas to anomaly-linked rows.
+- Prepare execution metadata for downstream guardrails.
+- Persist an audit-friendly staging artifact for Phase 5 and later phases.
 """
 
 from __future__ import annotations
 
+import ast
+import json
+import math
+import os
+from datetime import datetime, timezone
 from typing import Any
 
 
 REQUIRED_REMEDIATION_FIELDS = {
     "cluster_id",
+    "cluster_uid",
     "transformation_type",
     "code",
     "confidence_score",
@@ -27,7 +34,69 @@ REQUIRED_REMEDIATION_FIELDS = {
     "size",
     "cache_hit",
     "pattern_key",
+    "guardrail_action",
+    "risk_level",
+    "requires_human_review",
+    "validation_checks",
 }
+
+SAFE_GLOBALS = {
+    "__builtins__": {},
+    "str": str,
+    "int": int,
+    "float": float,
+    "len": len,
+    "min": min,
+    "max": max,
+    "abs": abs,
+    "round": round,
+}
+ALLOWED_AST_NODES = {
+    ast.Expression,
+    ast.Lambda,
+    ast.arguments,
+    ast.arg,
+    ast.Load,
+    ast.Name,
+    ast.Constant,
+    ast.IfExp,
+    ast.Compare,
+    ast.Eq,
+    ast.NotEq,
+    ast.Is,
+    ast.IsNot,
+    ast.In,
+    ast.NotIn,
+    ast.And,
+    ast.Or,
+    ast.BoolOp,
+    ast.UnaryOp,
+    ast.Not,
+    ast.USub,
+    ast.UAdd,
+    ast.BinOp,
+    ast.Add,
+    ast.Sub,
+    ast.Mult,
+    ast.Div,
+    ast.Mod,
+    ast.Pow,
+    ast.Call,
+    ast.Attribute,
+    ast.Subscript,
+    ast.Index,
+    ast.Slice,
+    ast.List,
+    ast.Tuple,
+    ast.Dict,
+}
+ALLOWED_CALL_NAMES = {"str", "int", "float", "len", "min", "max", "abs", "round"}
+ALLOWED_STRING_METHODS = {"replace", "strip", "lower", "upper"}
+
+
+def _ensure_dir(path: str) -> None:
+    if path:
+        os.makedirs(path, exist_ok=True)
 
 
 def _validate_remediation(remediation: dict[str, Any]) -> tuple[bool, list[str]]:
@@ -35,24 +104,36 @@ def _validate_remediation(remediation: dict[str, Any]) -> tuple[bool, list[str]]
     return (not missing, missing)
 
 
+def _build_invalid_record(remediation: dict[str, Any] | None, missing_fields: list[str]) -> dict[str, Any]:
+    remediation = remediation or {}
+    return {
+        "cluster_id": remediation.get("cluster_id", "unknown"),
+        "cluster_uid": remediation.get("cluster_uid", "unknown"),
+        "execution_status": "invalid_contract",
+        "ready_for_guardrails": False,
+        "missing_fields": missing_fields,
+        "transformation_type": "quarantine",
+        "guardrail_action": "quarantine",
+        "risk_level": "high",
+        "requires_human_review": True,
+        "validation_checks": remediation.get("validation_checks", []),
+    }
+
+
 def _build_execution_record(remediation: dict[str, Any]) -> dict[str, Any]:
     is_valid, missing = _validate_remediation(remediation)
     if not is_valid:
-        return {
-            "cluster_id": remediation.get("cluster_id", "unknown"),
-            "execution_status": "invalid_contract",
-            "ready_for_guardrails": False,
-            "missing_fields": missing,
-            "transformation_type": "quarantine",
-        }
+        return _build_invalid_record(remediation, missing)
 
     transformation_type = remediation["transformation_type"]
+    guardrail_action = remediation["guardrail_action"]
     execution_status = "staged"
-    if transformation_type == "quarantine":
+    if transformation_type == "quarantine" or guardrail_action == "quarantine":
         execution_status = "quarantined"
 
     return {
         "cluster_id": remediation["cluster_id"],
+        "cluster_uid": remediation["cluster_uid"],
         "execution_status": execution_status,
         "ready_for_guardrails": execution_status == "staged",
         "transformation_type": transformation_type,
@@ -60,10 +141,153 @@ def _build_execution_record(remediation: dict[str, Any]) -> dict[str, Any]:
         "confidence_score": remediation["confidence_score"],
         "reasoning": remediation["reasoning"],
         "fallback_value": remediation["fallback_value"],
+        "inferred_anomaly_type": remediation["inferred_anomaly_type"],
+        "model_used": remediation["model_used"],
         "member_ids": remediation["member_ids"],
         "size": remediation["size"],
+        "cache_hit": remediation["cache_hit"],
         "pattern_key": remediation["pattern_key"],
+        "guardrail_action": guardrail_action,
+        "risk_level": remediation["risk_level"],
+        "requires_human_review": remediation["requires_human_review"],
+        "validation_checks": remediation["validation_checks"],
+        "raw_response": remediation.get("raw_response"),
     }
+
+
+def _validate_lambda_ast(code: str) -> None:
+    tree = ast.parse(code, mode="eval")
+    for node in ast.walk(tree):
+        if type(node) not in ALLOWED_AST_NODES:
+            raise ValueError(f"Disallowed syntax in remediation code: {type(node).__name__}")
+        if isinstance(node, ast.Call):
+            if isinstance(node.func, ast.Name):
+                if node.func.id not in ALLOWED_CALL_NAMES:
+                    raise ValueError("Only simple safe built-in calls are allowed in remediation code")
+            elif isinstance(node.func, ast.Attribute):
+                if node.func.attr not in ALLOWED_STRING_METHODS:
+                    raise ValueError("Only safe string cleanup methods are allowed in remediation code")
+            else:
+                raise ValueError("Unsupported callable in remediation code")
+    if not isinstance(tree.body, ast.Lambda):
+        raise ValueError("Remediation code must be a lambda expression")
+
+
+def _compile_lambda(code: str):
+    _validate_lambda_ast(code)
+    compiled = eval(code, SAFE_GLOBALS, {})
+    if not callable(compiled):
+        raise ValueError("Remediation code did not compile to a callable lambda")
+    return compiled
+
+
+def _normalize_value(value: Any) -> Any:
+    if value in {"null", "None", "none", "NULL", "N/A", "n/a", ""}:
+        return None
+    return value
+
+
+def _safe_json_value(value: Any) -> Any:
+    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+        return None
+    return value
+
+
+def _remediation_id_candidates(member_id: str) -> list[str]:
+    candidates = [member_id]
+    if member_id.startswith("row_"):
+        candidates.append(member_id[4:])
+    return candidates
+
+
+def _build_anomaly_index(anomalies: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    index: dict[str, dict[str, Any]] = {}
+    for anomaly in anomalies:
+        if not isinstance(anomaly, dict):
+            continue
+        anomaly_id = anomaly.get("id")
+        if anomaly_id is not None:
+            index[str(anomaly_id)] = anomaly
+            index[f"row_{anomaly_id}"] = anomaly
+    return index
+
+
+def _apply_to_anomaly_rows(remediation: dict[str, Any], anomaly_index: dict[str, dict[str, Any]]) -> tuple[list[dict[str, Any]], list[str]]:
+    transformed_rows: list[dict[str, Any]] = []
+    unmatched_member_ids: list[str] = []
+    transformer = _compile_lambda(str(remediation["code"]))
+
+    for member_id in remediation["member_ids"]:
+        matched_row = None
+        for candidate in _remediation_id_candidates(str(member_id)):
+            matched_row = anomaly_index.get(candidate)
+            if matched_row is not None:
+                break
+
+        if matched_row is None:
+            unmatched_member_ids.append(str(member_id))
+            continue
+
+        original_value = matched_row.get("value")
+        source_row = matched_row.get("source_row")
+        target_column = matched_row.get("column_name") or matched_row.get("target_column")
+        transformed_value = transformer(_normalize_value(original_value))
+        transformed_value = _safe_json_value(transformed_value)
+
+        updated_source_row = None
+        if isinstance(source_row, dict):
+            updated_source_row = dict(source_row)
+            if target_column:
+                updated_source_row[str(target_column)] = transformed_value
+
+        transformed_rows.append(
+            {
+                "member_id": str(member_id),
+                "cluster_id": remediation["cluster_id"],
+                "cluster_uid": remediation["cluster_uid"],
+                "target_column": target_column,
+                "original_value": original_value,
+                "transformed_value": transformed_value,
+                "fallback_value": remediation["fallback_value"],
+                "source_row_before": source_row,
+                "source_row_after": updated_source_row,
+                "apply_status": "applied",
+            }
+        )
+
+    return transformed_rows, unmatched_member_ids
+
+
+def _stage_execution_rows(
+    record: dict[str, Any],
+    anomaly_index: dict[str, dict[str, Any]],
+) -> tuple[list[dict[str, Any]], dict[str, Any], dict[str, Any] | None]:
+    if record["execution_status"] != "staged":
+        return [], record, None
+
+    try:
+        transformed_rows, unmatched_member_ids = _apply_to_anomaly_rows(record, anomaly_index)
+    except Exception as exc:
+        failure_record = dict(record)
+        failure_record["execution_status"] = "execution_failed"
+        failure_record["ready_for_guardrails"] = False
+        failure_record["guardrail_action"] = "quarantine"
+        failure_record["risk_level"] = "high"
+        failure_record["requires_human_review"] = True
+        failure_record["execution_error"] = str(exc)
+        return [], record, failure_record
+
+    enriched_record = dict(record)
+    enriched_record["affected_rows"] = len(transformed_rows)
+    enriched_record["unmatched_member_ids"] = unmatched_member_ids
+    return transformed_rows, enriched_record, None
+
+
+def _write_execution_artifact(path: str, payload: dict[str, Any]) -> str:
+    _ensure_dir(os.path.dirname(path))
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, ensure_ascii=True, default=str)
+    return path
 
 
 def run(context: dict) -> dict:
@@ -71,53 +295,95 @@ def run(context: dict) -> dict:
     print("[Phase 4] Starting execution staging")
     updated_context = dict(context or {})
     remediations = updated_context.get("remediations", [])
+    anomalies = updated_context.get("anomalies", [])
+    vault_dir = str(updated_context.get("vault_dir", os.path.join("data", "vault")))
 
     if not isinstance(remediations, list) or not remediations:
         updated_context["execution_plan"] = []
+        updated_context["staged_remediations"] = []
+        updated_context["quarantined_remediations"] = []
+        updated_context["staged_execution_rows"] = []
         updated_context["phase4_status"] = "no_remediations"
         updated_context["phase4_summary"] = {
             "total": 0,
             "staged": 0,
             "quarantined": 0,
             "invalid_contract": 0,
+            "execution_failed": 0,
+            "applied_rows": 0,
         }
+        updated_context["phase4_execution_file"] = None
         return updated_context
 
+    anomaly_index = _build_anomaly_index(anomalies if isinstance(anomalies, list) else [])
     execution_plan: list[dict[str, Any]] = []
+    staged_remediations: list[dict[str, Any]] = []
+    quarantined_remediations: list[dict[str, Any]] = []
+    staged_execution_rows: list[dict[str, Any]] = []
     staged = 0
     quarantined = 0
     invalid_contract = 0
+    execution_failed = 0
 
     for remediation in remediations:
         if not isinstance(remediation, dict):
+            record = _build_invalid_record(None, ["<non-dict remediation>"])
             invalid_contract += 1
-            execution_plan.append(
-                {
-                    "cluster_id": "unknown",
-                    "execution_status": "invalid_contract",
-                    "ready_for_guardrails": False,
-                    "missing_fields": ["<non-dict remediation>"],
-                    "transformation_type": "quarantine",
-                }
-            )
+            quarantined_remediations.append(record)
+            execution_plan.append(record)
             continue
 
-        record = _build_execution_record(remediation)
-        status = record["execution_status"]
+        base_record = _build_execution_record(remediation)
+        status = base_record["execution_status"]
+        if status == "invalid_contract":
+            invalid_contract += 1
+            quarantined_remediations.append(base_record)
+            execution_plan.append(base_record)
+            continue
+
+        transformed_rows, enriched_record, execution_failure = _stage_execution_rows(base_record, anomaly_index)
+        if execution_failure is not None:
+            execution_failed += 1
+            quarantined += 1
+            quarantined_remediations.append(execution_failure)
+            execution_plan.append(execution_failure)
+            continue
+
         if status == "staged":
             staged += 1
+            staged_remediations.append(enriched_record)
+            staged_execution_rows.extend(transformed_rows)
         elif status == "quarantined":
             quarantined += 1
-        else:
-            invalid_contract += 1
-        execution_plan.append(record)
+            quarantined_remediations.append(base_record)
+        execution_plan.append(enriched_record if status == "staged" else base_record)
 
-    updated_context["execution_plan"] = execution_plan
-    updated_context["phase4_status"] = "completed"
-    updated_context["phase4_summary"] = {
-        "total": len(execution_plan),
-        "staged": staged,
-        "quarantined": quarantined,
-        "invalid_contract": invalid_contract,
+    artifact_payload = {
+        "generated_at_utc": datetime.now(timezone.utc).isoformat(),
+        "phase4_summary": {
+            "total": len(execution_plan),
+            "staged": staged,
+            "quarantined": quarantined,
+            "invalid_contract": invalid_contract,
+            "execution_failed": execution_failed,
+            "applied_rows": len(staged_execution_rows),
+        },
+        "execution_plan": execution_plan,
+        "staged_remediations": staged_remediations,
+        "quarantined_remediations": quarantined_remediations,
+        "staged_execution_rows": staged_execution_rows,
     }
+    execution_file = _write_execution_artifact(
+        os.path.join(vault_dir, "phase4_execution_plan.json"),
+        artifact_payload,
+    )
+
+    updated_context["vault_dir"] = vault_dir
+    updated_context["execution_plan"] = execution_plan
+    updated_context["staged_remediations"] = staged_remediations
+    updated_context["quarantined_remediations"] = quarantined_remediations
+    updated_context["staged_execution_rows"] = staged_execution_rows
+    updated_context["phase4_status"] = "completed"
+    updated_context["phase4_summary"] = artifact_payload["phase4_summary"]
+    updated_context["phase4_execution_file"] = execution_file
     return updated_context

--- a/tests/debug_phase1_runner.py
+++ b/tests/debug_phase1_runner.py
@@ -1,0 +1,67 @@
+"""
+Phase 1 debug runner for deterministic ingestion validation.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from phases.phase1_ingestion import run
+
+
+DEFAULT_INPUT_PATH = Path("data/raw/sample_data.csv")
+
+
+def _build_context(input_path: Path) -> dict:
+    return {
+        "input_path": str(input_path),
+        "source_name": input_path.stem,
+        "clean_dir": "data/clean",
+        "anomalies_dir": "data/anomalies",
+        "vault_dir": "data/vault",
+    }
+
+
+def _print_result(result: dict) -> None:
+    print("\n=== Phase 1 Result ===")
+    print(json.dumps(result.get("phase1_summary", {}), indent=2))
+    print(f"Phase 1 status: {result.get('phase1_status')}")
+    print(f"Clean output: {result.get('phase1_clean_file')}")
+    print(f"Anomaly output: {result.get('phase1_anomaly_file')}")
+
+    clean_rows = result.get("clean_rows", [])
+    anomalies = result.get("anomalies", [])
+
+    print(f"Clean row count: {len(clean_rows)}")
+    print(f"Anomaly count: {len(anomalies)}")
+
+    if clean_rows:
+        print("Clean preview:")
+        print(json.dumps(clean_rows[:2], indent=2, default=str))
+
+    if anomalies:
+        print("Anomaly preview:")
+        print(json.dumps(anomalies[:5], indent=2, default=str))
+
+
+def main() -> None:
+    input_arg = Path(sys.argv[1]) if len(sys.argv) > 1 else DEFAULT_INPUT_PATH
+    if not input_arg.exists():
+        raise FileNotFoundError(
+            f"Input dataset not found: {input_arg}. Pass a CSV/JSON/JSONL path as an argument."
+        )
+
+    print(f"Running Phase 1 with input: {input_arg}")
+    result = run(_build_context(input_arg))
+    _print_result(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -2,8 +2,258 @@
 Module: TEST - INGESTION
 Owner: Aadyaa
 Purpose:
-- Test ingestion and validation logic.
-Responsibilities:
-- Validate ingestion flow behavior.
-- Validate deterministic schema and rule checks.
+- Test deterministic Phase 1 ingestion behavior.
 """
+
+from __future__ import annotations
+
+import csv
+import json
+import sys
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from phases.phase1_ingestion import run
+
+
+def _write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fieldnames: list[str] = []
+    seen: set[str] = set()
+    for row in rows:
+        for key in row.keys():
+            if key not in seen:
+                seen.add(key)
+                fieldnames.append(key)
+
+    with path.open("w", encoding="utf-8", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _base_context(tmp_path: Path, input_path: Path | None = None) -> dict:
+    context = {
+        "clean_dir": str(tmp_path / "data" / "clean"),
+        "anomalies_dir": str(tmp_path / "data" / "anomalies"),
+        "vault_dir": str(tmp_path / "data" / "vault"),
+        "source_name": "phase1_test",
+    }
+    if input_path is not None:
+        context["input_path"] = str(input_path)
+    return context
+
+
+def test_run_phase1_handles_missing_input_gracefully(tmp_path: Path) -> None:
+    result = run(_base_context(tmp_path))
+
+    assert result["phase1_status"] == "missing_input"
+    assert result["clean_rows"] == []
+    assert result["anomalies"] == []
+    assert result["phase1_summary"]["input_rows"] == 0
+
+
+def test_run_phase1_passes_clean_rows_through(tmp_path: Path) -> None:
+    input_path = tmp_path / "data" / "raw" / "clean.csv"
+    _write_csv(
+        input_path,
+        [
+            {
+                "id": "101",
+                "transaction_date": "2024-03-12",
+                "customer_email": "nova@example.com",
+                "amount": "125.40",
+                "status": "ok",
+            }
+        ],
+    )
+
+    result = run(_base_context(tmp_path, input_path))
+
+    assert result["phase1_status"] == "completed"
+    assert result["phase1_summary"]["input_rows"] == 1
+    assert result["phase1_summary"]["clean_rows"] == 1
+    assert result["phase1_summary"]["anomalies"] == 0
+    assert len(result["clean_rows"]) == 1
+    assert result["anomalies"] == []
+    assert result["clean_rows"][0]["customer_email"] == "nova@example.com"
+
+
+def test_run_phase1_detects_invalid_date(tmp_path: Path) -> None:
+    input_path = tmp_path / "data" / "raw" / "bad_date.csv"
+    _write_csv(
+        input_path,
+        [
+            {
+                "id": "102",
+                "transaction_date": "03-12-2024",
+                "customer_email": "nova@example.com",
+                "amount": "125.40",
+            }
+        ],
+    )
+
+    result = run(_base_context(tmp_path, input_path))
+
+    assert result["phase1_summary"]["clean_rows"] == 0
+    assert result["phase1_summary"]["anomalies"] == 1
+    anomaly = result["anomalies"][0]
+    assert anomaly["column_name"] == "transaction_date"
+    assert anomaly["error_type"] == "date_format_error"
+    assert anomaly["anomaly_hint"] == "date token format mismatch"
+
+
+def test_run_phase1_detects_upstream_style_invalid_slash_date(tmp_path: Path) -> None:
+    input_path = tmp_path / "data" / "raw" / "bad_slash_date.csv"
+    _write_csv(
+        input_path,
+        [
+            {
+                "id": "102b",
+                "transaction_date": "2024/03/12",
+                "customer_email": "nova@example.com",
+                "amount": "125.40",
+            }
+        ],
+    )
+
+    result = run(_base_context(tmp_path, input_path))
+
+    anomaly = result["anomalies"][0]
+    assert anomaly["column_name"] == "transaction_date"
+    assert anomaly["error_type"] == "date_format_error"
+
+
+def test_run_phase1_detects_invalid_email(tmp_path: Path) -> None:
+    input_path = tmp_path / "data" / "raw" / "bad_email.csv"
+    _write_csv(
+        input_path,
+        [
+            {
+                "id": "103",
+                "transaction_date": "2024-03-12",
+                "customer_email": "not-an-email",
+                "amount": "125.40",
+            }
+        ],
+    )
+
+    result = run(_base_context(tmp_path, input_path))
+
+    anomaly = result["anomalies"][0]
+    assert anomaly["column_name"] == "customer_email"
+    assert anomaly["error_type"] == "email_format_error"
+    assert anomaly["anomaly_hint"] == "email token malformed address"
+
+
+def test_run_phase1_detects_upstream_style_double_dot_email(tmp_path: Path) -> None:
+    input_path = tmp_path / "data" / "raw" / "bad_double_dot_email.csv"
+    _write_csv(
+        input_path,
+        [
+            {
+                "id": "103b",
+                "transaction_date": "2024-03-12",
+                "customer_email": "user..dot@mail.com",
+                "amount": "125.40",
+            }
+        ],
+    )
+
+    result = run(_base_context(tmp_path, input_path))
+
+    anomaly = result["anomalies"][0]
+    assert anomaly["column_name"] == "customer_email"
+    assert anomaly["error_type"] == "email_format_error"
+
+
+def test_run_phase1_detects_invalid_numeric(tmp_path: Path) -> None:
+    input_path = tmp_path / "data" / "raw" / "bad_numeric.csv"
+    _write_csv(
+        input_path,
+        [
+            {
+                "id": "104",
+                "transaction_date": "2024-03-12",
+                "customer_email": "nova@example.com",
+                "amount": "12,5O",
+            }
+        ],
+    )
+
+    result = run(_base_context(tmp_path, input_path))
+
+    anomaly = result["anomalies"][0]
+    assert anomaly["column_name"] == "amount"
+    assert anomaly["error_type"] == "numeric_format_error"
+    assert anomaly["anomaly_hint"] == "amount contains numeric separator noise"
+
+
+def test_run_phase1_detects_upstream_style_whitespace_numeric(tmp_path: Path) -> None:
+    input_path = tmp_path / "data" / "raw" / "bad_whitespace_numeric.csv"
+    _write_csv(
+        input_path,
+        [
+            {
+                "id": "104b",
+                "transaction_date": "2024-03-12",
+                "customer_email": "nova@example.com",
+                "amount": " 999.00 ",
+            }
+        ],
+    )
+
+    result = run(_base_context(tmp_path, input_path))
+
+    anomaly = result["anomalies"][0]
+    assert anomaly["column_name"] == "amount"
+    assert anomaly["error_type"] == "numeric_format_error"
+
+
+def test_run_phase1_detects_null_like_values(tmp_path: Path) -> None:
+    input_path = tmp_path / "data" / "raw" / "bad_null.csv"
+    _write_csv(
+        input_path,
+        [
+            {
+                "id": "105",
+                "transaction_date": "2024-03-12",
+                "customer_email": "missing",
+                "amount": "125.40",
+            }
+        ],
+    )
+
+    result = run(_base_context(tmp_path, input_path))
+
+    anomaly = result["anomalies"][0]
+    assert anomaly["column_name"] == "customer_email"
+    assert anomaly["error_type"] == "null_block_error"
+    assert anomaly["anomaly_hint"] == "value is missing or sentinel null"
+
+
+def test_run_phase1_writes_phase2_ready_anomaly_json(tmp_path: Path) -> None:
+    input_path = tmp_path / "data" / "raw" / "bad_payload.csv"
+    _write_csv(
+        input_path,
+        [
+            {
+                "id": "106",
+                "transaction_date": "03-12-2024",
+                "customer_email": "bad-email",
+                "amount": "12,5O",
+            }
+        ],
+    )
+
+    result = run(_base_context(tmp_path, input_path))
+    anomaly_file = Path(result["phase1_anomaly_file"])
+    payload = json.loads(anomaly_file.read_text(encoding="utf-8"))
+
+    assert isinstance(payload, list)
+    assert len(payload) == 3
+    assert {"id", "column_name", "value", "error_type", "anomaly_hint"}.issubset(payload[0].keys())

--- a/tests/test_phase4_execution.py
+++ b/tests/test_phase4_execution.py
@@ -1,49 +1,175 @@
+import json
+import os
+import tempfile
 import unittest
 
+from phases import phase3_slm_remediation as phase3
 from phases import phase4_execution
 
 
 class Phase4ExecutionTests(unittest.TestCase):
-    def test_stages_valid_remediation(self):
-        context = {
-            "remediations": [
-                {
-                    "cluster_id": "cluster_1",
-                    "transformation_type": "rule",
-                    "code": "lambda x: x",
-                    "confidence_score": 0.82,
-                    "reasoning": "Conservative rule selected.",
-                    "fallback_value": "null",
-                    "inferred_anomaly_type": "date_format",
-                    "model_used": "mock/static",
-                    "member_ids": ["row_1"],
-                    "size": 1,
-                    "cache_hit": False,
-                    "pattern_key": "date-pattern",
-                }
-            ]
+    def _valid_remediation(self) -> dict:
+        return {
+            "cluster_id": "cluster_1",
+            "cluster_uid": "nova_cluster_00001",
+            "transformation_type": "rule",
+            "code": "lambda x: x",
+            "confidence_score": 0.82,
+            "reasoning": "Conservative rule selected.",
+            "fallback_value": "null",
+            "inferred_anomaly_type": "date_format",
+            "model_used": "mock/static",
+            "member_ids": ["row_1"],
+            "size": 1,
+            "cache_hit": False,
+            "pattern_key": "date-pattern",
+            "guardrail_action": "staging_only",
+            "risk_level": "medium",
+            "requires_human_review": False,
+            "validation_checks": ["schema_check", "null_safety_check"],
+            "raw_response": '{"transformation_type":"rule"}',
         }
 
-        result = phase4_execution.run(context)
+    def _anomaly_rows(self) -> list[dict]:
+        return [
+            {
+                "id": 1,
+                "column_name": "amount",
+                "value": "1,200.50",
+                "error_type": "numeric_format_error",
+                "anomaly_hint": "amount contains numeric separator noise",
+                "source_row": {
+                    "id": 1,
+                    "amount": "1,200.50",
+                    "customer_email": "nova@example.com",
+                },
+            }
+        ]
 
-        self.assertEqual(result["phase4_status"], "completed")
-        self.assertEqual(result["phase4_summary"]["staged"], 1)
-        self.assertEqual(result["execution_plan"][0]["execution_status"], "staged")
+    def test_stages_valid_remediation(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            context = {
+                "vault_dir": tmp_dir,
+                "remediations": [self._valid_remediation()],
+            }
+
+            result = phase4_execution.run(context)
+
+            self.assertEqual(result["phase4_status"], "completed")
+            self.assertEqual(result["phase4_summary"]["staged"], 1)
+            self.assertEqual(result["execution_plan"][0]["execution_status"], "staged")
+            self.assertEqual(result["execution_plan"][0]["cluster_uid"], "nova_cluster_00001")
+            self.assertEqual(result["execution_plan"][0]["guardrail_action"], "staging_only")
+            self.assertTrue(os.path.exists(result["phase4_execution_file"]))
+
+    def test_applies_safe_lambda_to_anomaly_rows(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            remediation = self._valid_remediation()
+            remediation["code"] = "lambda x: None if x is None else str(x).replace(',', '')"
+            remediation["member_ids"] = ["row_1"]
+            remediation["inferred_anomaly_type"] = "type_cast"
+
+            result = phase4_execution.run(
+                {
+                    "vault_dir": tmp_dir,
+                    "remediations": [remediation],
+                    "anomalies": self._anomaly_rows(),
+                }
+            )
+
+            self.assertEqual(result["phase4_summary"]["applied_rows"], 1)
+            self.assertEqual(len(result["staged_execution_rows"]), 1)
+            self.assertEqual(result["staged_execution_rows"][0]["transformed_value"], "1200.50")
+            self.assertEqual(result["staged_execution_rows"][0]["source_row_after"]["amount"], "1200.50")
+
+    def test_quarantine_remediation_is_split_out(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            remediation = self._valid_remediation()
+            remediation["transformation_type"] = "quarantine"
+            remediation["guardrail_action"] = "quarantine"
+            remediation["requires_human_review"] = True
+
+            result = phase4_execution.run({"vault_dir": tmp_dir, "remediations": [remediation]})
+
+            self.assertEqual(result["phase4_summary"]["quarantined"], 1)
+            self.assertEqual(len(result["staged_remediations"]), 0)
+            self.assertEqual(len(result["quarantined_remediations"]), 1)
+            self.assertEqual(result["quarantined_remediations"][0]["execution_status"], "quarantined")
+
+    def test_execution_failure_quarantines_record(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            remediation = self._valid_remediation()
+            remediation["code"] = "lambda x: __import__('os').system('echo nope')"
+
+            result = phase4_execution.run(
+                {
+                    "vault_dir": tmp_dir,
+                    "remediations": [remediation],
+                    "anomalies": self._anomaly_rows(),
+                }
+            )
+
+            self.assertEqual(result["phase4_summary"]["execution_failed"], 1)
+            self.assertEqual(result["quarantined_remediations"][0]["execution_status"], "execution_failed")
+            self.assertIn("execution_error", result["quarantined_remediations"][0])
 
     def test_flags_invalid_contract(self):
-        context = {
-            "remediations": [
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            context = {
+                "vault_dir": tmp_dir,
+                "remediations": [
+                    {
+                        "cluster_id": "cluster_2",
+                        "transformation_type": "rule",
+                    }
+                ],
+            }
+
+            result = phase4_execution.run(context)
+
+            self.assertEqual(result["phase4_summary"]["invalid_contract"], 1)
+            self.assertEqual(result["execution_plan"][0]["execution_status"], "invalid_contract")
+            self.assertIn("cluster_uid", result["execution_plan"][0]["missing_fields"])
+
+    def test_writes_execution_artifact_payload(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            result = phase4_execution.run({"vault_dir": tmp_dir, "remediations": [self._valid_remediation()]})
+
+            with open(result["phase4_execution_file"], "r", encoding="utf-8") as handle:
+                payload = json.load(handle)
+
+            self.assertIn("execution_plan", payload)
+            self.assertIn("staged_remediations", payload)
+            self.assertIn("quarantined_remediations", payload)
+            self.assertIn("staged_execution_rows", payload)
+            self.assertEqual(payload["phase4_summary"]["staged"], 1)
+
+    def test_phase3_output_flows_into_phase4(self):
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            os.environ["PHASE3_PROVIDER"] = "mock"
+            phase3_result = phase3.run(
                 {
-                    "cluster_id": "cluster_2",
-                    "transformation_type": "rule",
+                    "clusters": [
+                        {
+                            "cluster_id": "cluster_4",
+                            "cluster_uid": "nova_cluster_00004",
+                            "sample_rows": [{"amount": "1,200.50"}],
+                            "size": 1,
+                            "member_ids": ["row_4"],
+                            "cache_hit": False,
+                            "pattern_key": "numeric-format",
+                            "target_column": "amount",
+                        }
+                    ]
                 }
-            ]
-        }
+            )
 
-        result = phase4_execution.run(context)
+            phase4_result = phase4_execution.run({"vault_dir": tmp_dir, **phase3_result})
 
-        self.assertEqual(result["phase4_summary"]["invalid_contract"], 1)
-        self.assertEqual(result["execution_plan"][0]["execution_status"], "invalid_contract")
+            self.assertEqual(phase4_result["phase4_status"], "completed")
+            self.assertEqual(phase4_result["phase4_summary"]["total"], 1)
+            self.assertIn(phase4_result["execution_plan"][0]["execution_status"], {"staged", "quarantined", "execution_failed"})
+            self.assertIn("guardrail_action", phase4_result["execution_plan"][0])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- upgrade Phase 4 from scaffold-level execution staging to a medium-level execution engine
- preserve full Phase 3 guardrail metadata for downstream phases
- add safe lambda execution for anomaly-linked row staging
- write an audit-friendly execution artifact for Phase 5 and later phases

## What Changed
- expanded `phases/phase4_execution.py` to validate the full Phase 3 remediation contract
- preserved remediation fields such as:
  - `cluster_uid`
  - `guardrail_action`
  - `risk_level`
  - `requires_human_review`
  - `validation_checks`
- added:
  - `execution_plan`
  - `staged_remediations`
  - `quarantined_remediations`
  - `staged_execution_rows`
  - `phase4_execution_file`
- implemented restricted AST-based lambda validation before execution
- applied safe remediation logic to anomaly-linked rows using `member_ids`
- captured before/after staged row state for auditability
- routed unsafe/failed execution attempts into quarantine-style handling
- persisted `phase4_execution_plan.json` as an execution staging artifact

## Validation
```bash
python -m pytest tests/test_phase3_slm_remediation.py tests/test_phase4_execution.py -q
